### PR TITLE
Gradle 7.6.4

### DIFF
--- a/gradle-blackbaud-7.6.4-bb.1.0-bin.zip
+++ b/gradle-blackbaud-7.6.4-bb.1.0-bin.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44ef0c1593f1c397ba6a1c67c8fd87ed1ebefad7cd6c4aa1e7085b6411451ccc
+size 122702502


### PR DESCRIPTION
Update base to Gradle 7.6.4 to fix issues encountered with multi-version jars like jackson-core-2.16.1